### PR TITLE
Custom estate icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Requires Origo 2.1.1 or later and a Origoserver
           },
           "pageEstateReportWidth": "700px",
           "pageEstateReportHeight": "500px",
-          "pageEstateReportUrl": "https://example.com/origoserver/estate/inskrivning?objektid="
+          "pageEstateReportUrl": "https://example.com/origoserver/estate/inskrivning?objektid=",
+          "pageEstateIconText": '<text font-size="1em" font-family="Arial" font-weight="bold" fill="black"><tspan x="5" dy="1.2em">Fastighets-</tspan><tspan x="5" dy="1.2em">rapport</tspan></text>',
+          "pageEstateIconSize": [96, 48]
         });
         viewer.addComponent(lmsearch);
     	});
@@ -156,6 +158,8 @@ The configuration options explained:
 - pageEstateReportUrl - the URL to the page for the estate report, default is empty string.
 
 - pageEstateIconText - the text which should be displayed withen estate report icon, default is `<text x="5" y="40" font-size="45" font-family="Arial" fill="black">FI</text>`.
+
+- pageEstateIconSize - an array with the width and height, in pixels, to use for the estate icon rectangle, default is `[50, 50]`.
 
 #### Coordinate reference systems
 

--- a/src/lmsearch.js
+++ b/src/lmsearch.js
@@ -30,7 +30,8 @@ const Lmsearch = function Lmsearch(options = {}) {
     pageEstateReportWidth,
     pageEstateReportHeight,
     pageEstateReportUrl,
-    pageEstateIconText
+    pageEstateIconText,
+    pageEstateIconSize
   } = options;
 
   let viewer;
@@ -70,7 +71,8 @@ const Lmsearch = function Lmsearch(options = {}) {
         pageEstateReportWidth,
         pageEstateReportHeight,
         pageEstateReportUrl,
-        pageEstateIconText
+        pageEstateIconText,
+        pageEstateIconSize
       });
       this.addComponent(search);
       this.render();

--- a/src/lmsearch/main.js
+++ b/src/lmsearch/main.js
@@ -334,7 +334,7 @@ const Main = function Main(options = {}) {
 
       function dbToList() {
         const items = Object.keys(searchDb);
-        return items.map(item => searchDb[item]);
+        return items.map((item) => searchDb[item]);
       }
 
       function setSearchDb(data) {
@@ -352,10 +352,11 @@ const Main = function Main(options = {}) {
         setSearchDb([]);
       }
 
-      const handler = function func(data) {
-        if (data.length === 0) {
+      function responseHandler(data) {
+        let result = data;
+        if (result.length === 0) {
           console.log('Ingen träff');
-          data = [{
+          result = [{
             NAMN: ' ',
             value: ' ',
             layer: 'Ingen träff'
@@ -365,17 +366,30 @@ const Main = function Main(options = {}) {
         list = [];
         searchDb = {};
 
-        if (data.length) {
-          setSearchDb(data);
+        if (result.length) {
+          setSearchDb(result);
           if (name && layerNameAttribute) {
             list = groupToList(groupDb(searchDb));
           } else {
-            list = dbToList(data);
+            list = dbToList(result);
           }
           awesomplete.list = list;
           awesomplete.evaluate();
         }
-      };
+      }
+
+      // we need to use this function bcuz IE does not understand spread syntax!
+      function flattenData(data) {
+        const flatData = [];
+        for (let i = 0; i < data.length; i += 1) {
+          const item = data[i];
+          for (let j = 0; j < item.length; j += 1) {
+            const innerItem = item[j];
+            flatData.push(innerItem);
+          }
+        }
+        return flatData;
+      }
 
       function makeRequest2(handler, obj) {
         let data = [];
@@ -401,19 +415,6 @@ const Main = function Main(options = {}) {
       }
       // }
 
-      // we need to use this function bcuz IE does not understand spread syntax!
-      function flattenData(data) {
-        const flatData = [];
-        for (let i = 0; i < data.length; i += 1) {
-          const item = data[i];
-          for (let j = 0; j < item.length; j += 1) {
-            const innerItem = item[j];
-            flatData.push(innerItem);
-          }
-        }
-        return flatData;
-      }
-
       const delay = (function delay() {
         let timer = 0;
         return function timeout(callback, ms) {
@@ -429,7 +430,7 @@ const Main = function Main(options = {}) {
           if (keyCode in keyCodes) {
             // empty
           } else {
-            delay(() => { makeRequest2(handler, that); }, 500);
+            delay(() => { makeRequest2(responseHandler, that); }, 500);
           }
         }
       });

--- a/src/lmsearch/main.js
+++ b/src/lmsearch/main.js
@@ -56,7 +56,8 @@ const Main = function Main(options = {}) {
     pageEstateReportWidth = '700px',
     pageEstateReportHeight = '500px',
     pageEstateReportUrl = '',
-    pageEstateIconText = '<text x="5" y="40" font-size="45" font-family="Arial" fill="black">FI</text>'
+    pageEstateIconText = '<text x="5" y="40" font-size="45" font-family="Arial" fill="black">FI</text>',
+    pageEstateIconSize = [50, 50]
   } = options;
   let {
     maxZoomLevel
@@ -97,7 +98,7 @@ const Main = function Main(options = {}) {
   let estateLookupOn = false;
   let target;
   const vectorStyles = Origo.Style.createStyleRule(featureStyles);
-  const svgFI = `<svg width="50" height="50" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect width="50" height="50" style="fill:rgba(255,255,255,0.5);stroke-width:5;stroke:rgb(0,0,0)" />${pageEstateIconText}</svg>`;
+  const svgFI = `<svg width="${pageEstateIconSize[0]}" height="${pageEstateIconSize[1]}" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect width="${pageEstateIconSize[0]}" height="${pageEstateIconSize[1]}" style="fill:rgba(255,255,255,0.5);stroke-width:5;stroke:rgb(0,0,0)" />${pageEstateIconText}</svg>`;
   const iconStyle = new Style({
     image: new Icon({
       src: `data:image/svg+xml;utf8,${svgFI}`,


### PR DESCRIPTION
Fixes #42.

Added a new config option `pageEstateIconSize` with a default value of `[50, 50]` that controls the width and height of the SVG rectangle of the estate icon.

Added a README entry and custom text+size to the config example.

Also fixed some linter errors.