### PR TITLE
Fix casing of import

### DIFF
--- a/src/lmsearch.js
+++ b/src/lmsearch.js
@@ -1,6 +1,6 @@
 // Importing Origo framework and the main module for the search functionality
 import Origo from 'Origo';
-import Main from './lmsearch/Main';
+import Main from './lmsearch/main';
 
 // Defining the Lmsearch component as a function
 const Lmsearch = function Lmsearch(options = {}) {

--- a/src/lmsearch/prepsuggestions.js
+++ b/src/lmsearch/prepsuggestions.js
@@ -1,6 +1,6 @@
 import communeCodes from './communecodes';
+import _ from 'lodash';
 
-const _ = require('lodash');
 /*
   {
    "NAMN": "Erik vallers väg 12a",


### PR DESCRIPTION
Import uses wrong casing (`Main`, while the file is named `main`). This doesn't matter on case-insensitive file systems (such as Windows), while breaking on case-sensitive file systems (pretty much any other OS).

The import from `Origo` being title-cased as well is also slightly annoying, however that cannot be changed without introducing a break on backwards compatibility.